### PR TITLE
Implement manifest.json copying in Vite build process

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,16 +1,36 @@
 import { defineConfig } from 'vite';
 import { resolve } from 'path';
+import { copyFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// manifest.jsonをコピーするプラグイン
+const copyManifestPlugin = () => {
+  return {
+    name: 'copy-manifest',
+    writeBundle() {
+      const srcManifest = resolve(__dirname, 'src/manifest.json');
+      const destManifest = resolve(__dirname, 'dist/manifest.json');
+      copyFileSync(srcManifest, destManifest);
+      console.log('[vite] manifest.json copied to dist/');
+    },
+  };
+};
 
 export default defineConfig({
+  plugins: [copyManifestPlugin()],
   build: {
     rollupOptions: {
       input: {
-        popup: resolve(__dirname, 'src/popup/popup.html'),
-        background: resolve(__dirname, 'src/background/background.js'),
-        content: resolve(__dirname, 'src/content/content.js'),
+        'popup/popup': resolve(__dirname, 'src/popup/popup.html'),
+        'background/background': resolve(__dirname, 'src/background/background.js'),
+        'content/content': resolve(__dirname, 'src/content/content.js'),
       },
       output: {
-        entryFileNames: `[name].js`,
+        entryFileNames: '[name].js',
       },
     },
     outDir: 'dist',


### PR DESCRIPTION
- Added a custom Vite plugin to copy manifest.json from the src directory to the dist directory during the build process.
- Updated the build configuration to include the new plugin for better management of the manifest file.