### PR TITLE
次へボタン検出と処理状態の安定化

### DIFF
--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -167,6 +167,6 @@
     </div>
   </div>
 
-  <script src="popup.js"></script>
+  <script type="module" src="./popup.js"></script>
 </body>
 </html>

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,6 @@
 import { defineConfig } from 'vite';
 import { resolve } from 'path';
-import { copyFileSync } from 'fs';
+import { copyFileSync, readFileSync, writeFileSync, existsSync, renameSync, mkdirSync, rmSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { dirname } from 'path';
 
@@ -20,8 +20,71 @@ const copyManifestPlugin = () => {
   };
 };
 
+// popup.htmlを正しい場所に移動し、パスを修正するプラグイン
+const fixPopupHtmlPlugin = () => {
+  return {
+    name: 'fix-popup-html',
+    writeBundle() {
+      // まず、間違った場所にあるpopup.htmlを確認
+      const wrongPath = resolve(__dirname, 'dist/src/popup/popup.html');
+      const correctPath = resolve(__dirname, 'dist/popup/popup.html');
+      const correctDir = resolve(__dirname, 'dist/popup');
+      const wrongDir = resolve(__dirname, 'dist/src');
+      
+      try {
+        // 間違った場所にファイルがある場合、正しい場所に移動
+        if (existsSync(wrongPath)) {
+          // popupディレクトリが存在しない場合は作成
+          if (!existsSync(correctDir)) {
+            mkdirSync(correctDir, { recursive: true });
+          }
+          // ファイルを移動
+          renameSync(wrongPath, correctPath);
+          console.log('[vite] popup.html moved from dist/src/popup/ to dist/popup/');
+          
+          // 空になったsrcディレクトリを削除
+          try {
+            const srcPopupDir = resolve(__dirname, 'dist/src/popup');
+            if (existsSync(srcPopupDir)) {
+              rmSync(srcPopupDir, { recursive: true, force: true });
+            }
+            if (existsSync(wrongDir)) {
+              // srcディレクトリが空か確認して削除
+              try {
+                rmSync(wrongDir, { recursive: true, force: true });
+                console.log('[vite] Removed empty dist/src/ directory');
+              } catch (e) {
+                // ディレクトリが空でない場合は無視
+              }
+            }
+          } catch (e) {
+            // 削除エラーは無視
+          }
+        }
+        
+        // 正しい場所のpopup.htmlのパスを修正
+        if (existsSync(correctPath)) {
+          let html = readFileSync(correctPath, 'utf-8');
+          // Viteが生成したパスを修正（相対パスに）
+          // 様々なパターンに対応
+          html = html.replace(/src="[^"]*popup\.js"/g, 'src="./popup.js"');
+          html = html.replace(/src="[^"]*\/popup\/popup\.js"/g, 'src="./popup.js"');
+          html = html.replace(/src="\.\/popup\/popup\.js"/g, 'src="./popup.js"');
+          html = html.replace(/src="[^"]*\/src\/popup\/popup\.js"/g, 'src="./popup.js"');
+          writeFileSync(correctPath, html, 'utf-8');
+          console.log('[vite] popup.html paths fixed');
+        } else {
+          console.warn('[vite] popup.html not found at:', correctPath);
+        }
+      } catch (error) {
+        console.warn('[vite] Could not fix popup.html:', error.message);
+      }
+    },
+  };
+};
+
 export default defineConfig({
-  plugins: [copyManifestPlugin()],
+  plugins: [copyManifestPlugin(), fixPopupHtmlPlugin()],
   build: {
     rollupOptions: {
       input: {
@@ -31,8 +94,20 @@ export default defineConfig({
       },
       output: {
         entryFileNames: '[name].js',
+        chunkFileNames: '[name]-[hash].js',
+        assetFileNames: (assetInfo) => {
+          // HTMLファイルは元のディレクトリ構造を維持
+          if (assetInfo.name && assetInfo.name.endsWith('.html')) {
+            const name = assetInfo.name;
+            if (name.includes('popup')) {
+              return 'popup/popup.html';
+            }
+          }
+          return '[name][extname]';
+        },
       },
     },
     outDir: 'dist',
+    emptyOutDir: true,
   },
 });


### PR DESCRIPTION
## Summary
- 次へボタンのセレクタを更新し、フォールバックとログを追加
- Content Scriptの初期化/再送制御を強化し、既存タブでも処理を継続
- ポップアップ再オープン時の状態同期と進捗表示を改善
- ビルド後のpopup配置とパス修正を追加

## Test plan
- [ ] 取得開始後、ページ送りとPDF生成が継続する
- [ ] ポップアップ再オープン後も停止ボタンが有効
- [ ] 進捗表示が"12/0"にならず"12 ページ処理中"になる
- [ ] npm run build後にdist/popup/popup.htmlが正しく配置される